### PR TITLE
[bug] Fixed updating the camera position.

### DIFF
--- a/components/Camera.js
+++ b/components/Camera.js
@@ -264,7 +264,7 @@ Camera.prototype.onUpdate = function onUpdate() {
  * @return {Camera} this
  */
 Camera.prototype.onTransformChange = function onTransformChange(transform) {
-    var a = transform;
+    var a = transform.local;
     this._viewDirty = true;
 
     if (!this._requestingUpdate) {


### PR DESCRIPTION
It ended up being the viewTransform for Camera was not getting updated, all values were NaN. viewTransform now updates properly. I also discovered FRUSTUM_PROJECTION is being deprecated it seems, which is probably worth bringing back. setDepth() on Camera activates PINHOLE_PROJECTION. There is also ORTHOGRAPHIC_PROJECTION, but here you will loose perspective. 
